### PR TITLE
Jobs service

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,15 +18,15 @@ try {
 
     $service->get('/docs', Swagger::class);
 
-    $service->post('/api/v0.2/hold-requests', HoldRequestController::class . ':createHoldRequest');
+    $service->post('/api/v0.1/hold-requests', HoldRequestController::class . ':createHoldRequest');
 
-    $service->get('/api/v0.2/hold-requests', HoldRequestController::class . ':getHoldRequests');
+    $service->get('/api/v0.1/hold-requests', HoldRequestController::class . ':getHoldRequests');
 
-    $service->get('/api/v0.2/hold-requests/{id}', HoldRequestController::class . ':getHoldRequest');
+    $service->get('/api/v0.1/hold-requests/{id}', HoldRequestController::class . ':getHoldRequest');
 
-    $service->put('/api/v0.2/hold-requests/{id}', HoldRequestController::class . ':updateHoldRequest');
+    $service->put('/api/v0.1/hold-requests/{id}', HoldRequestController::class . ':updateHoldRequest');
 
-    $service->post('/api/v0.2/hold-requests/{id}/result', HoldRequestResultController::class . ':processResult');
+    $service->post('/api/v0.1/hold-requests/{id}/result', HoldRequestResultController::class . ':processResult');
 
     $service->run();
 } catch (\Exception $exception) {

--- a/src/Controller/HoldRequestController.php
+++ b/src/Controller/HoldRequestController.php
@@ -1,11 +1,11 @@
 <?php
 namespace NYPL\Services\Controller;
 
+use NYPL\Services\JobService;
 use NYPL\Services\ServiceController;
 use NYPL\Services\Model\HoldRequest\HoldRequest;
 use NYPL\Services\Model\HoldRequestResponse;
 use NYPL\Starter\Filter;
-use Ramsey\Uuid\Uuid;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
@@ -18,7 +18,7 @@ class HoldRequestController extends ServiceController
 {
     /**
      * @SWG\Post(
-     *     path="/v0.2/hold-requests",
+     *     path="/v0.1/hold-requests",
      *     summary="Create new hold request",
      *     tags={"hold-requests"},
      *     operationId="createHoldRequest",
@@ -61,7 +61,7 @@ class HoldRequestController extends ServiceController
     {
         $data = $this->getRequest()->getParsedBody();
 
-        $data['jobId'] = Uuid::uuid4()->toString();
+        $data['jobId'] = JobService::generateJobId($this->useJobManager);
         $data['success'] = $data['processed'] = false;
 
         $holdRequest = new HoldRequest($data);
@@ -75,7 +75,7 @@ class HoldRequestController extends ServiceController
 
     /**
      * @SWG\Get(
-     *     path="/v0.2/hold-requests",
+     *     path="/v0.1/hold-requests",
      *     summary="Get a list of hold requests",
      *     tags={"hold-requests"},
      *     operationId="getHoldRequests",
@@ -138,7 +138,7 @@ class HoldRequestController extends ServiceController
 
     /**
      * @SWG\Get(
-     *     path="/v0.2/hold-requests/{id}",
+     *     path="/v0.1/hold-requests/{id}",
      *     summary="Get a single hold request",
      *     tags={"hold-requests"},
      *     operationId="getHoldRequest",
@@ -196,7 +196,7 @@ class HoldRequestController extends ServiceController
 
     /**
      * @SWG\Put(
-     *     path="/v0.2/hold-requests/{id}",
+     *     path="/v0.1/hold-requests/{id}",
      *     summary="Update a hold request",
      *     tags={"hold-requests"},
      *     operationId="updateHoldRequest",

--- a/src/Controller/HoldRequestController.php
+++ b/src/Controller/HoldRequestController.php
@@ -61,7 +61,7 @@ class HoldRequestController extends ServiceController
     {
         $data = $this->getRequest()->getParsedBody();
 
-        $data['jobId'] = JobService::generateJobId($this->useJobManager);
+        $data['jobId'] = JobService::generateJobId();
         $data['success'] = $data['processed'] = false;
 
         $holdRequest = new HoldRequest($data);

--- a/src/JobService.php
+++ b/src/JobService.php
@@ -1,0 +1,66 @@
+<?php
+namespace NYPL\Services;
+
+use NYPL\Starter\APIException;
+use NYPL\Starter\APILogger;
+use NYPL\Starter\JobManager;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Class JobService
+ *
+ * @package NYPL\Services
+ */
+class JobService
+{
+    /**
+     * @var string
+     */
+    public static $jobId;
+
+    /**
+     * @param bool $useJobManager
+     * @throws \NYPL\Starter\APIException
+     * @return string
+     */
+    public static function generateJobId($useJobManager = true): string
+    {
+        if ($useJobManager) {
+            try {
+                $jobId = JobManager::createJob();
+                self::setJobId($jobId);
+            } catch (\Exception $exception) {
+                APILogger::addError('Not able to communicate with the Jobs Service API.');
+                throw new APIException('Jobs Service failed to generate an ID.');
+            }
+        }
+
+        if (!self::getJobId()) {
+            self::generateRandomId();
+            APILogger::addInfo('No job started. Job ID returned as UUID.');
+        }
+
+        return self::getJobId();
+    }
+
+    /**
+     * @return string|null
+     */
+    protected static function getJobId()
+    {
+        return self::$jobId;
+    }
+
+    /**
+     * @param string $jobId
+     */
+    protected static function setJobId(string $jobId)
+    {
+        self::$jobId = $jobId;
+    }
+
+    protected static function generateRandomId()
+    {
+        self::setJobId(Uuid::uuid4()->toString());
+    }
+}

--- a/src/ServiceController.php
+++ b/src/ServiceController.php
@@ -1,7 +1,6 @@
 <?php
 namespace NYPL\Services;
 
-use NYPL\Starter\Config;
 use NYPL\Starter\Controller;
 use Slim\Container;
 
@@ -16,11 +15,6 @@ class ServiceController extends Controller
      * @var Container
      */
     public $container;
-
-    /**
-     * @var bool
-     */
-    public $useJobManager;
 
     /**
      * Controller constructor.
@@ -39,8 +33,6 @@ class ServiceController extends Controller
 
         $this->initializeIdentityHeader();
 
-        $this->setUseJobManager(Config::get('USE_JOB_MANAGER'));
-
         parent::__construct($this->request, $this->response, $cacheSeconds);
     }
 
@@ -58,21 +50,5 @@ class ServiceController extends Controller
     public function setContainer($container)
     {
         $this->container = $container;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getUseJobManager()
-    {
-        return $this->useJobManager;
-    }
-
-    /**
-     * @param mixed $useJobManager
-     */
-    public function setUseJobManager($useJobManager)
-    {
-        $this->useJobManager = $useJobManager;
     }
 }

--- a/src/ServiceController.php
+++ b/src/ServiceController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NYPL\Services;
 
+use NYPL\Starter\Config;
 use NYPL\Starter\Controller;
 use Slim\Container;
 
@@ -17,9 +18,9 @@ class ServiceController extends Controller
     public $container;
 
     /**
-     * @var array
+     * @var bool
      */
-    public $parameters;
+    public $useJobManager;
 
     /**
      * Controller constructor.
@@ -38,6 +39,8 @@ class ServiceController extends Controller
 
         $this->initializeIdentityHeader();
 
+        $this->setUseJobManager(Config::get('USE_JOB_MANAGER'));
+
         parent::__construct($this->request, $this->response, $cacheSeconds);
     }
 
@@ -55,5 +58,21 @@ class ServiceController extends Controller
     public function setContainer($container)
     {
         $this->container = $container;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUseJobManager()
+    {
+        return $this->useJobManager;
+    }
+
+    /**
+     * @param mixed $useJobManager
+     */
+    public function setUseJobManager($useJobManager)
+    {
+        $this->useJobManager = $useJobManager;
     }
 }

--- a/tests/JobServiceTest.php
+++ b/tests/JobServiceTest.php
@@ -30,7 +30,7 @@ class JobServiceTest extends TestCase
     }
 
     /**
-     * @covers JobService
+     * @covers \NYPL\Services\JobService
      */
     public function testIfJobIdIsUnique()
     {
@@ -41,7 +41,7 @@ class JobServiceTest extends TestCase
     }
 
     /**
-     * @covers JobService
+     * @covers \NYPL\Services\JobService
      */
     public function testIfJobIdIsValidUuid()
     {

--- a/tests/JobServiceTest.php
+++ b/tests/JobServiceTest.php
@@ -14,23 +14,40 @@ class JobServiceTest extends TestCase
     {
         $this->fakeJobService = new class extends JobService {
 
-        public static $jobId = null;
+            public static function generateJobId($useJobManager = true): string
+            {
+                if ($useJobManager) {
+                    $serviceId = (string) uniqid();
+                } else {
+                    $serviceId = Uuid::uuid4();
+                }
+
+                return $serviceId;
+            }
 
         };
         parent::setUp();
     }
 
-    public function testifJobIdIsUnique()
+    /**
+     * @covers JobService
+     */
+    public function testIfJobIdIsUnique()
     {
-        $uniqueId = uniqid();
+        $fakeService = $this->fakeJobService;
+        $uniqueId = $fakeService::generateJobId();
 
         self::assertNotNull($uniqueId);
     }
 
+    /**
+     * @covers JobService
+     */
     public function testIfJobIdIsValidUuid()
     {
         $useJobManager = false;
-        $uuid = JobService::generateJobId($useJobManager);
+        $fakeService = $this->fakeJobService;
+        $uuid = $fakeService::generateJobId($useJobManager);
 
         self::assertTrue(Uuid::isValid($uuid));
     }

--- a/tests/JobServiceTest.php
+++ b/tests/JobServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace NYPL\Services\Test;
+
+use NYPL\Services\JobService;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class JobServiceTest extends TestCase
+{
+
+    public $fakeJobService;
+
+    public function setUp()
+    {
+        $this->fakeJobService = new class extends JobService {
+
+        public static $jobId = null;
+
+        };
+        parent::setUp();
+    }
+
+    public function testifJobIdIsUnique()
+    {
+        $uniqueId = uniqid();
+
+        self::assertNotNull($uniqueId);
+    }
+
+    public function testIfJobIdIsValidUuid()
+    {
+        $useJobManager = false;
+        $uuid = JobService::generateJobId($useJobManager);
+
+        self::assertTrue(Uuid::isValid($uuid));
+    }
+
+}

--- a/tests/Model/NewHoldRequestTest.php
+++ b/tests/Model/NewHoldRequestTest.php
@@ -19,6 +19,9 @@ class NewHoldRequestTest extends TestCase
         parent::setUp();
     }
 
+    /**
+     * @covers NewHoldRequest
+     */
     public function testAlwaysReturnsValidRequestType()
     {
         $this->assertEquals('hold', $this->fakeHoldRequest->requestType);

--- a/tests/Model/NewHoldRequestTest.php
+++ b/tests/Model/NewHoldRequestTest.php
@@ -20,7 +20,7 @@ class NewHoldRequestTest extends TestCase
     }
 
     /**
-     * @covers NewHoldRequest
+     * @covers \NYPL\Services\Model\HoldRequest\NewHoldRequest
      */
     public function testAlwaysReturnsValidRequestType()
     {

--- a/tests/Model/NewHoldRequestTest.php
+++ b/tests/Model/NewHoldRequestTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace NYPL\Serices\Test;
 
 use NYPL\Services\Model\HoldRequest\NewHoldRequest;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Adds ability to create a Job on HoldRequest creation and a possible fall back or basic generated UUID for tracking in lieu of a Job API. We may need to discuss what happens if the Job API is not available. Does the request fail or do we proceed with the fall back UUID as the tracking ID? How does this get handled now in the Alpha?

Also fixes the base version in endpoints from v0.2 to v0.1 for compatibility/swappability.